### PR TITLE
Release 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Other combinations might also work but have not been tested.
 
 | Release | Camunda Platform 8 | Camunda Platform 7 |
 |---------|--------------------|--------------------|
-| 2.0.2   | 8.2.3              | 7.19.0             |
 | 2.0.3   | 8.3.0              | 7.19.0             |
 | 2.1.0   | 8.3.0              | 7.20.0             |
+| 2.1.1   | 8.4.0              | 7.20.0             |
 
 <details>
 
@@ -104,6 +104,7 @@ Other combinations might also work but have not been tested.
 | 2.0.2   | 8.2.3              | 7.19.0             |
 | 2.0.3   | 8.3.0              | 7.19.0             |
 | 2.1.0   | 8.3.0              | 7.20.0             |
+| 2.1.1   | 8.4.0              | 7.20.0             |
 
 </details>
 

--- a/api/api-carbon-aware-computing/pom.xml
+++ b/api/api-carbon-aware-computing/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm.api</groupId>
         <artifactId>api</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
 
     <artifactId>api-carbon-aware-computing</artifactId>

--- a/api/api-carbon-aware-computing/pom.xml
+++ b/api/api-carbon-aware-computing/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm.api</groupId>
         <artifactId>api</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>api-carbon-aware-computing</artifactId>

--- a/api/api-carbon-aware/pom.xml
+++ b/api/api-carbon-aware/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>api</artifactId>
         <groupId>de.envite.greenbpm.api</groupId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/api-carbon-aware/pom.xml
+++ b/api/api-carbon-aware/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>api</artifactId>
         <groupId>de.envite.greenbpm.api</groupId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm</groupId>
         <artifactId>CarbonReductorConnector</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>de.envite.greenbpm.api</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm</groupId>
         <artifactId>CarbonReductorConnector</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
 
     <groupId>de.envite.greenbpm.api</groupId>

--- a/camunda-carbon-reductor-c7/Dockerfile
+++ b/camunda-carbon-reductor-c7/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.8.3-openjdk-17 AS BUILD
 COPY . .
-RUN mvn clean package
+RUN mvn clean package -DskipTests
 
 FROM openjdk:17.0.1-jdk-slim AS RUN
 

--- a/camunda-carbon-reductor-c7/pom.xml
+++ b/camunda-carbon-reductor-c7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm</groupId>
         <artifactId>CarbonReductorConnector</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
 
     <groupId>de.envite.greenbpm.carbonreductorconnector</groupId>

--- a/camunda-carbon-reductor-c7/pom.xml
+++ b/camunda-carbon-reductor-c7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.envite.greenbpm</groupId>
         <artifactId>CarbonReductorConnector</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
 
     <groupId>de.envite.greenbpm.carbonreductorconnector</groupId>

--- a/camunda-carbon-reductor-c8/Dockerfile
+++ b/camunda-carbon-reductor-c8/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.8.3-openjdk-17 AS BUILD
 COPY . .
-RUN mvn clean package
+RUN mvn clean package -DskipTests
 
 FROM openjdk:17.0.1-jdk-slim AS RUN
 

--- a/camunda-carbon-reductor-c8/pom.xml
+++ b/camunda-carbon-reductor-c8/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>CarbonReductorConnector</artifactId>
         <groupId>de.envite.greenbpm</groupId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camunda-carbon-reductor-c8/pom.xml
+++ b/camunda-carbon-reductor-c8/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>CarbonReductorConnector</artifactId>
         <groupId>de.envite.greenbpm</groupId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/carbon-reductor-core/pom.xml
+++ b/carbon-reductor-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>CarbonReductorConnector</artifactId>
         <groupId>de.envite.greenbpm</groupId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/carbon-reductor-core/pom.xml
+++ b/carbon-reductor-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>CarbonReductorConnector</artifactId>
         <groupId>de.envite.greenbpm</groupId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>de.envite.greenbpm</groupId>
     <artifactId>CarbonReductorConnector</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1</version>
+    <version>2.1.2-SNAPSHOT</version>
 
     <modules>
         <module>api</module>
@@ -53,7 +53,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>${project.scm.url}</url>
-        <tag>v2.1.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>de.envite.greenbpm</groupId>
     <artifactId>CarbonReductorConnector</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
 
     <modules>
         <module>api</module>
@@ -53,7 +53,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>${project.scm.url}</url>
-        <tag>HEAD</tag>
+        <tag>v2.1.1</tag>
     </scm>
 
     <build>


### PR DESCRIPTION
See:
* [https://hub.docker.com/layers/enviteconsulting/camunda-8-carbon-reductor-connector/2.1.1](https://hub.docker.com/layers/enviteconsulting/camunda-8-carbon-reductor-connector/2.1.1/images/sha256-7dee32bb3e762f24cac2fcfd93d012671261ec3990ea0920bc3107fcd9c86cce?context=explore)
* [https://hub.docker.com/layers/enviteconsulting/camunda-7-carbon-reductor-connector/2.1.1](https://hub.docker.com/layers/enviteconsulting/camunda-7-carbon-reductor-connector/2.1.1/images/sha256-ce8854421c7a7eae0a8d090f55f1bc7923790f286c3596c828cebfc81e280027?context=explore)

A [release](https://github.com/envite-consulting/camunda-carbon-reductor/releases) is already waiting as a draft 🙂 